### PR TITLE
cambios de estado paused, eliminacion y generacion de turnos

### DIFF
--- a/src/modules/turno/turnClear.service.ts
+++ b/src/modules/turno/turnClear.service.ts
@@ -16,7 +16,8 @@ export class TurnoCleanupService {
     await this.turnoService.deleteOldTurnos();
   }
   async deleteTurno(arrayTurnoId: string[]) {
+    console.log('deleteTurno');
     await this.turnoRepository.delete(arrayTurnoId);
-    return 'Turnos eliminados correctamente';
+    return { message: 'Turnos eliminados correctamente' };
   }
 }

--- a/src/modules/turno/turnoGenerator.service.ts
+++ b/src/modules/turno/turnoGenerator.service.ts
@@ -2,7 +2,7 @@ import { Repository, In, LessThan } from 'typeorm';
 import { Turno } from './turno.entity';
 import { Cancha } from '../cancha/cancha.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Status } from './status.enum';
 import { Cron } from '@nestjs/schedule';
 
@@ -18,7 +18,6 @@ export class TurnoGeneratorService {
       where: { paused: false },
     });
     const dates = this.getNext10Days();
-
     const turnosExistentes = await this.turnoRepository.find({
       where: {
         date: In(dates),
@@ -62,14 +61,51 @@ export class TurnoGeneratorService {
     return 'Turnos generados exitosamente';
   }
 
-  async deleteOldTurnos(): Promise<void> {
-    const now = new Date();
-    const cutoffDate = new Date(now.getTime() - 60 * 60 * 1000);
-    const cutoffDateString = cutoffDate.toISOString().split('T')[0];
-
-    await this.turnoRepository.delete({
-      date: LessThan(cutoffDateString),
+  async genereteTurnosid(canchaId: string) {
+    const cancha = await this.canchaRepository.findOne({
+      where: { id: canchaId },
     });
+    if (!cancha) {
+      throw new NotFoundException('Cancha no encontrada');
+    }
+    const dates = this.getNext10Days();
+    const turnosExistentes = await this.turnoRepository.find({
+      where: {
+        date: In(dates),
+        cancha: { id: cancha.id },
+      },
+    });
+
+    const turnosMap = new Map<string, boolean>();
+    for (const turno of turnosExistentes) {
+      const key = `${turno.date}-${turno.cancha.id}`;
+      turnosMap.set(key, true);
+    }
+
+    const newTurnos = [];
+    const open = parseInt(cancha.timeopen.split(':')[0], 10);
+    const close = parseInt(cancha.timeclose.split(':')[0], 10);
+
+    for (const date of dates) {
+      const key = `${date}-${cancha.id}`;
+      if (turnosMap.has(key)) {
+        continue;
+      }
+      for (let i = open; i < close; i++) {
+        const time = `${i < 10 ? '0' + i : i}:00`;
+        const turno = {
+          date: date,
+          time: time,
+          cancha: cancha,
+          status: Status.Libre,
+        };
+        newTurnos.push(turno);
+      }
+    }
+    if (newTurnos.length > 0) {
+      await this.turnoRepository.save(newTurnos);
+    }
+    return 'Turnos generados exitosamente para la cancha';
   }
 
   private getNext10Days() {
@@ -80,5 +116,14 @@ export class TurnoGeneratorService {
       dates.push(date.toISOString().split('T')[0]);
     }
     return dates;
+  }
+  async deleteOldTurnos(): Promise<void> {
+    const now = new Date();
+    const cutoffDate = new Date(now.getTime() - 60 * 60 * 1000);
+    const cutoffDateString = cutoffDate.toISOString().split('T')[0];
+
+    await this.turnoRepository.delete({
+      date: LessThan(cutoffDateString),
+    });
   }
 }


### PR DESCRIPTION
si se llama a la ruta para pausar la cancha detecta si esta o no pausada, en caso de que no elimina todos los turnos libres y cambia el estado a paused=true para que no le genere mas turnos automaticos, si llama y la cancha esta pausada la reactiva y le crea turnos para los proximos 10 dias y queda como paused=false